### PR TITLE
Install Sass by default (for SCSS w. CSS Modules)

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -407,7 +407,7 @@ function run(
     getInstallPackage(version, originalDirectory),
     getTemplateInstallPackage(template, originalDirectory),
   ]).then(([packageToInstall, templateToInstall]) => {
-    const allDependencies = ['react', 'react-dom', packageToInstall];
+    const allDependencies = ['react', 'react-dom', 'sass', packageToInstall];
 
     console.log('Installing packages. This might take a couple of minutes.');
 
@@ -454,7 +454,7 @@ function run(
         console.log(
           `Installing ${chalk.cyan('react')}, ${chalk.cyan(
             'react-dom'
-          )}, and ${chalk.cyan(packageInfo.name)}${
+          )},  ${chalk.cyan('sass')} and ${chalk.cyan(packageInfo.name)}${
             supportsTemplates ? ` with ${chalk.cyan(templateInfo.name)}` : ''
           }...`
         );


### PR DESCRIPTION
We teach primarily CSS Modules + SCSS since a few cohorts now, so let's also install `sass` to avoid an extra step for students